### PR TITLE
SWARM-1389: Add nexus-staging-maven-plugin to pluginManagement and updated jboss-parent.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,15 @@
   ~
   ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.jboss</groupId>
     <artifactId>jboss-parent</artifactId>
-    <version>21</version>
-    <relativePath />
+    <version>23</version>
+    <relativePath/>
   </parent>
 
   <groupId>org.wildfly.swarm</groupId>
@@ -61,6 +62,15 @@
         </configuration>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.sonatype.plugins</groupId>
+          <artifactId>nexus-staging-maven-plugin</artifactId>
+          <version>1.6.8</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <profiles>
@@ -71,7 +81,6 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.3</version>
             <extensions>true</extensions>
             <configuration>
               <nexusUrl>https://oss.sonatype.org/</nexusUrl>

--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
   <parent>
     <groupId>org.jboss</groupId>
     <artifactId>jboss-parent</artifactId>
-    <version>23</version>
-    <relativePath/>
+    <version>21</version>
+    <relativePath />
   </parent>
 
   <groupId>org.wildfly.swarm</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <plugin>
           <groupId>org.sonatype.plugins</groupId>
           <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>1.6.8</version>
+          <version>1.6.3</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Motivation
----------
Remove warnings in build about nexus-staging-maven-plugin version not being defined

Modifications
-------------
Updated jboss-parent to 23 and added nexus-staging-maven-plugin to the pluginManagement section

Result
------
No errors when using this pom as the parent in core